### PR TITLE
add 5s sleep to avoid docker attach race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= mcr.microsoft.com/aks/canipull:v0.0.3-alpha
+IMG ?= mcr.microsoft.com/aks/canipull:v0.0.5-alpha
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/doc/kubectl-check_acr
+++ b/doc/kubectl-check_acr
@@ -36,7 +36,7 @@ if [ -z "$acr" ]; then
   exit 1
 fi
 
-image="mcr.microsoft.com/aks/canipull:0.0.4-alpha"
+image="mcr.microsoft.com/aks/canipull:0.0.5-alpha"
 pod="canipull-$(env LC_ALL=C tr -dc a-z0-9 < /dev/urandom | head -c 6)"
 
 overrides="$(


### PR DESCRIPTION
same issue as https://github.com/kubernetes/kubernetes/issues/27264#issuecomment-911818844
It is possible for canipull cannot output any log when docker run finished in 5s